### PR TITLE
fix: ignore user_weight in VoteForGaugeEvent

### DIFF
--- a/src/Curve/mappings/GaugeController.ts
+++ b/src/Curve/mappings/GaugeController.ts
@@ -49,7 +49,8 @@ export function handleVoteForGauge(event: VoteForGaugeEvent): void {
     event.block.timestamp,
     event.address, // controller
     event.params.gauge_addr, // gauge
-    event.params.weight, // gaugeWeight
+    // event.params.weight is the user_weight for this vote -> ignore it
+    null, // gaugeWeight
     null // totalWeight
   );
 }

--- a/src/Curve/mappings/GaugeController.ts
+++ b/src/Curve/mappings/GaugeController.ts
@@ -49,7 +49,6 @@ export function handleVoteForGauge(event: VoteForGaugeEvent): void {
     event.block.timestamp,
     event.address, // controller
     event.params.gauge_addr, // gauge
-    // event.params.weight is the user_weight for this vote -> ignore it
     null, // gaugeWeight
     null // totalWeight
   );


### PR DESCRIPTION
Like stated in Discourse the `gaugeWeight` in `CurveGaugeData` was always way too low.

Turns out we have to ignore the `user_weight` in `VoteForGaugeEvent`, so that the correct weight is pulled from the blockchain.