### PR TITLE
Fix Compound Rewards #OE-49

### DIFF
--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -398,7 +398,15 @@
               "symbol": "cZRX",
               "address": "0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407",
               "startBlock": 7710733
-            }
+            },
+            { "address": "0xccf4429db6322d5c611ee964527d42e5d685dd6a", "startBlock": "12038653", "symbol": "cWBTC2" },
+            { "address": "0xf5dce57282a584d2746faf1593d3121fcac444dc", "startBlock": "7710752", "symbol": "cSAI" },
+            { "address": "0x4b0181102a0112a2ef11abee5563bb4a3176c9d7", "startBlock": "12848166", "symbol": "cSUSHI" },
+            { "address": "0x12392f67bdf24fae0af363c24ac620a2f67dad86", "startBlock": "11008385", "symbol": "cTUSD" },
+            { "address": "0xe65cdb6479bac1e22340e4e755fae7e509ecd06c", "startBlock": "12848198", "symbol": "cAAVE" },
+            { "address": "0x80a2ae356fc9ef4305676f7a3e2ed04e12c33946", "startBlock": "12848198", "symbol": "cYFI" },
+            { "address": "0xface851a4921ce59e912d19329929ce6da6eb0c7", "startBlock": "12286030", "symbol": "cLINK" },
+            { "address": "0x95b4ef2869ebd94beb4eee400a99824bf5dc325b", "startBlock": "12836064", "symbol": "cMKR" }
           ]
         }
       ]

--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -286,7 +286,7 @@
       "contracts": [
         {
           "contract": "ComptrollerImplementation",
-          "abis": ["ComptrollerImplementation", "Token", "Underlying"],
+          "abis": ["ComptrollerImplementation"],
           "entities": ["CompoundTokenData"],
           "events": [
             {
@@ -303,8 +303,30 @@
           ]
         },
         {
+          "contract": "ComptrollerImplementationV2",
+          "abis": ["ComptrollerImplementationV2"],
+          "entities": ["CompoundTokenData"],
+          "events": [
+            {
+              "event-name": "CompBorrowSpeedUpdated",
+              "event-params": "(indexed address,uint256)"
+            },
+            {
+              "event-name": "CompSupplySpeedUpdated",
+              "event-params": "(indexed address,uint256)"
+            }
+          ],
+          "instances": [
+            {
+              "symbol": "",
+              "address": "0x3d9819210A31b4961b30EF54bE2aeD79B9c9Cd3B",
+              "startBlock": 13322798
+            }
+          ]
+        },
+        {
           "contract": "Token",
-          "abis": ["ComptrollerImplementation", "Token", "Underlying"],
+          "abis": ["ComptrollerImplementation", "ComptrollerImplementationV2", "Token", "Underlying"],
           "entities": ["CompoundTokenData"],
           "events": [
             {

--- a/schema.graphql
+++ b/schema.graphql
@@ -77,7 +77,8 @@ type CompoundTokenData @entity {
   blockTimestamp: BigInt
   borrowIndex: BigDecimal
   borrowRatePerBlock: BigDecimal
-  compSpeed: BigDecimal
+  compBorrowSpeed: BigDecimal
+  compSupplySpeed: BigDecimal
   cTokenSymbol: String
   cTokenAddress: Bytes
   exchangeRate: BigDecimal

--- a/script/add-symlinks.sh
+++ b/script/add-symlinks.sh
@@ -4,10 +4,11 @@
 
 if [[ "$CONFIG" == "arbitrum" ]]
 then
-  ln -s CurvePoolX22pool      generated/CurvePoolX2
-  ln -s CurvePoolX3tricrypto  generated/CurvePoolX3
+  ln -s CurvePoolX22pool     generated/CurvePoolX2
+  ln -s CurvePoolX3tricrypto generated/CurvePoolX3
   # PoolX4 is not used
-  ln -s generated/CurvePoolX3tricrypto  generated/CurvePoolX4
+  ln -s CurvePoolX3tricrypto generated/CurvePoolX4
+  ln -s CurvePoolX3.ts       generated/CurvePoolX4/CurvePoolX4.ts
 elif [[ "$CONFIG" == "polygon" ]]
 then
   ln -s CurvePoolX2aAAVE generated/CurvePoolX2

--- a/src/Compound/abis/ComptrollerImplementationV2.json
+++ b/src/Compound/abis/ComptrollerImplementationV2.json
@@ -1,0 +1,1074 @@
+[
+  { "inputs": [], "payable": false, "stateMutability": "nonpayable", "type": "constructor" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "string", "name": "action", "type": "string" },
+      { "indexed": false, "internalType": "bool", "name": "pauseState", "type": "bool" }
+    ],
+    "name": "ActionPaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "contract CToken", "name": "cToken", "type": "address" },
+      { "indexed": false, "internalType": "string", "name": "action", "type": "string" },
+      { "indexed": false, "internalType": "bool", "name": "pauseState", "type": "bool" }
+    ],
+    "name": "ActionPaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "oldCompAccrued", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newCompAccrued", "type": "uint256" }
+    ],
+    "name": "CompAccruedAdjusted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract CToken", "name": "cToken", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "newSpeed", "type": "uint256" }
+    ],
+    "name": "CompBorrowSpeedUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "recipient", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "CompGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "oldCompReceivable", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newCompReceivable", "type": "uint256" }
+    ],
+    "name": "CompReceivableUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract CToken", "name": "cToken", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "newSpeed", "type": "uint256" }
+    ],
+    "name": "CompSupplySpeedUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "contributor", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "newSpeed", "type": "uint256" }
+    ],
+    "name": "ContributorCompSpeedUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract CToken", "name": "cToken", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "compDelta", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "compBorrowIndex", "type": "uint256" }
+    ],
+    "name": "DistributedBorrowerComp",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract CToken", "name": "cToken", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "supplier", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "compDelta", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "compSupplyIndex", "type": "uint256" }
+    ],
+    "name": "DistributedSupplierComp",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "error", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "info", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "detail", "type": "uint256" }
+    ],
+    "name": "Failure",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "contract CToken", "name": "cToken", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "MarketEntered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "contract CToken", "name": "cToken", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "MarketExited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "contract CToken", "name": "cToken", "type": "address" }],
+    "name": "MarketListed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract CToken", "name": "cToken", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "newBorrowCap", "type": "uint256" }
+    ],
+    "name": "NewBorrowCap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldBorrowCapGuardian", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newBorrowCapGuardian", "type": "address" }
+    ],
+    "name": "NewBorrowCapGuardian",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldCloseFactorMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newCloseFactorMantissa", "type": "uint256" }
+    ],
+    "name": "NewCloseFactor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "contract CToken", "name": "cToken", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "oldCollateralFactorMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newCollateralFactorMantissa", "type": "uint256" }
+    ],
+    "name": "NewCollateralFactor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldLiquidationIncentiveMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newLiquidationIncentiveMantissa", "type": "uint256" }
+    ],
+    "name": "NewLiquidationIncentive",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldPauseGuardian", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newPauseGuardian", "type": "address" }
+    ],
+    "name": "NewPauseGuardian",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "contract PriceOracle", "name": "oldPriceOracle", "type": "address" },
+      { "indexed": false, "internalType": "contract PriceOracle", "name": "newPriceOracle", "type": "address" }
+    ],
+    "name": "NewPriceOracle",
+    "type": "event"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "contract Unitroller", "name": "unitroller", "type": "address" }],
+    "name": "_become",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "_borrowGuardianPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "_grantComp",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "_mintGuardianPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "newBorrowCapGuardian", "type": "address" }],
+    "name": "_setBorrowCapGuardian",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "contract CToken", "name": "cToken", "type": "address" },
+      { "internalType": "bool", "name": "state", "type": "bool" }
+    ],
+    "name": "_setBorrowPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "newCloseFactorMantissa", "type": "uint256" }],
+    "name": "_setCloseFactor",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "contract CToken", "name": "cToken", "type": "address" },
+      { "internalType": "uint256", "name": "newCollateralFactorMantissa", "type": "uint256" }
+    ],
+    "name": "_setCollateralFactor",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "contract CToken[]", "name": "cTokens", "type": "address[]" },
+      { "internalType": "uint256[]", "name": "supplySpeeds", "type": "uint256[]" },
+      { "internalType": "uint256[]", "name": "borrowSpeeds", "type": "uint256[]" }
+    ],
+    "name": "_setCompSpeeds",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "contributor", "type": "address" },
+      { "internalType": "uint256", "name": "compSpeed", "type": "uint256" }
+    ],
+    "name": "_setContributorCompSpeed",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "newLiquidationIncentiveMantissa", "type": "uint256" }],
+    "name": "_setLiquidationIncentive",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "contract CToken[]", "name": "cTokens", "type": "address[]" },
+      { "internalType": "uint256[]", "name": "newBorrowCaps", "type": "uint256[]" }
+    ],
+    "name": "_setMarketBorrowCaps",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "contract CToken", "name": "cToken", "type": "address" },
+      { "internalType": "bool", "name": "state", "type": "bool" }
+    ],
+    "name": "_setMintPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "newPauseGuardian", "type": "address" }],
+    "name": "_setPauseGuardian",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "contract PriceOracle", "name": "newOracle", "type": "address" }],
+    "name": "_setPriceOracle",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "bool", "name": "state", "type": "bool" }],
+    "name": "_setSeizePaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "bool", "name": "state", "type": "bool" }],
+    "name": "_setTransferPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "contract CToken", "name": "cToken", "type": "address" }],
+    "name": "_supportMarket",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "name": "accountAssets",
+    "outputs": [{ "internalType": "contract CToken", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "admin",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "allMarkets",
+    "outputs": [{ "internalType": "contract CToken", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "cToken", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }
+    ],
+    "name": "borrowAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "borrowCapGuardian",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "borrowCaps",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "borrowGuardianPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "cToken", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }
+    ],
+    "name": "borrowVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "contract CToken", "name": "cToken", "type": "address" }
+    ],
+    "name": "checkMembership",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "holder", "type": "address" },
+      { "internalType": "contract CToken[]", "name": "cTokens", "type": "address[]" }
+    ],
+    "name": "claimComp",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address[]", "name": "holders", "type": "address[]" },
+      { "internalType": "contract CToken[]", "name": "cTokens", "type": "address[]" },
+      { "internalType": "bool", "name": "borrowers", "type": "bool" },
+      { "internalType": "bool", "name": "suppliers", "type": "bool" }
+    ],
+    "name": "claimComp",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "holder", "type": "address" }],
+    "name": "claimComp",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "closeFactorMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "compAccrued",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "compBorrowSpeeds",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "compBorrowState",
+    "outputs": [
+      { "internalType": "uint224", "name": "index", "type": "uint224" },
+      { "internalType": "uint32", "name": "block", "type": "uint32" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
+    ],
+    "name": "compBorrowerIndex",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "compContributorSpeeds",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "compInitialIndex",
+    "outputs": [{ "internalType": "uint224", "name": "", "type": "uint224" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "compRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "compReceivable",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "compSpeeds",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
+    ],
+    "name": "compSupplierIndex",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "compSupplySpeeds",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "compSupplyState",
+    "outputs": [
+      { "internalType": "uint224", "name": "index", "type": "uint224" },
+      { "internalType": "uint32", "name": "block", "type": "uint32" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "comptrollerImplementation",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address[]", "name": "cTokens", "type": "address[]" }],
+    "name": "enterMarkets",
+    "outputs": [{ "internalType": "uint256[]", "name": "", "type": "uint256[]" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "cTokenAddress", "type": "address" }],
+    "name": "exitMarket",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address[]", "name": "affectedUsers", "type": "address[]" },
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }
+    ],
+    "name": "fixBadAccruals",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "getAccountLiquidity",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getAllMarkets",
+    "outputs": [{ "internalType": "contract CToken[]", "name": "", "type": "address[]" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "getAssetsIn",
+    "outputs": [{ "internalType": "contract CToken[]", "name": "", "type": "address[]" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getBlockNumber",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getCompAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "address", "name": "cTokenModify", "type": "address" },
+      { "internalType": "uint256", "name": "redeemTokens", "type": "uint256" },
+      { "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }
+    ],
+    "name": "getHypotheticalAccountLiquidity",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "isComptroller",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "contract CToken", "name": "cToken", "type": "address" }],
+    "name": "isDeprecated",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "lastContributorBlock",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "cTokenBorrowed", "type": "address" },
+      { "internalType": "address", "name": "cTokenCollateral", "type": "address" },
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "liquidateBorrowAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "cTokenBorrowed", "type": "address" },
+      { "internalType": "address", "name": "cTokenCollateral", "type": "address" },
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "actualRepayAmount", "type": "uint256" },
+      { "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "liquidateBorrowVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "cTokenBorrowed", "type": "address" },
+      { "internalType": "address", "name": "cTokenCollateral", "type": "address" },
+      { "internalType": "uint256", "name": "actualRepayAmount", "type": "uint256" }
+    ],
+    "name": "liquidateCalculateSeizeTokens",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "liquidationIncentiveMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "markets",
+    "outputs": [
+      { "internalType": "bool", "name": "isListed", "type": "bool" },
+      { "internalType": "uint256", "name": "collateralFactorMantissa", "type": "uint256" },
+      { "internalType": "bool", "name": "isComped", "type": "bool" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "maxAssets",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "cToken", "type": "address" },
+      { "internalType": "address", "name": "minter", "type": "address" },
+      { "internalType": "uint256", "name": "mintAmount", "type": "uint256" }
+    ],
+    "name": "mintAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "mintGuardianPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "cToken", "type": "address" },
+      { "internalType": "address", "name": "minter", "type": "address" },
+      { "internalType": "uint256", "name": "actualMintAmount", "type": "uint256" },
+      { "internalType": "uint256", "name": "mintTokens", "type": "uint256" }
+    ],
+    "name": "mintVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "oracle",
+    "outputs": [{ "internalType": "contract PriceOracle", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pauseGuardian",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pendingAdmin",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pendingComptrollerImplementation",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "proposal65FixExecuted",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "cToken", "type": "address" },
+      { "internalType": "address", "name": "redeemer", "type": "address" },
+      { "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }
+    ],
+    "name": "redeemAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "cToken", "type": "address" },
+      { "internalType": "address", "name": "redeemer", "type": "address" },
+      { "internalType": "uint256", "name": "redeemAmount", "type": "uint256" },
+      { "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }
+    ],
+    "name": "redeemVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "cToken", "type": "address" },
+      { "internalType": "address", "name": "payer", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "repayBorrowAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "cToken", "type": "address" },
+      { "internalType": "address", "name": "payer", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "actualRepayAmount", "type": "uint256" },
+      { "internalType": "uint256", "name": "borrowerIndex", "type": "uint256" }
+    ],
+    "name": "repayBorrowVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "cTokenCollateral", "type": "address" },
+      { "internalType": "address", "name": "cTokenBorrowed", "type": "address" },
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "seizeAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "seizeGuardianPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "cTokenCollateral", "type": "address" },
+      { "internalType": "address", "name": "cTokenBorrowed", "type": "address" },
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "seizeVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "cToken", "type": "address" },
+      { "internalType": "address", "name": "src", "type": "address" },
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "transferTokens", "type": "uint256" }
+    ],
+    "name": "transferAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "transferGuardianPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "cToken", "type": "address" },
+      { "internalType": "address", "name": "src", "type": "address" },
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "transferTokens", "type": "uint256" }
+    ],
+    "name": "transferVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "contributor", "type": "address" }],
+    "name": "updateContributorRewards",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/Compound/mappings/ComptrollerImplementation.ts
+++ b/src/Compound/mappings/ComptrollerImplementation.ts
@@ -8,6 +8,7 @@ export function handleCompSpeedUpdated(event: CompSpeedUpdatedEvent): void {
     event.block.timestamp,
     event.address, // comptrollerAddress
     event.params.newSpeed,
+    event.params.newSpeed,
     event.params.cToken,
     null, // borrowIndex
     null, // totalBorrows

--- a/src/Compound/mappings/ComptrollerImplementationV2.ts
+++ b/src/Compound/mappings/ComptrollerImplementationV2.ts
@@ -1,0 +1,33 @@
+import {
+  CompBorrowSpeedUpdated as CompBorrowSpeedUpdatedEvent,
+  CompSupplySpeedUpdated as CompSupplySpeedUpdatedEvent,
+} from "../../../generated/CompoundComptrollerImplementationV2/CompoundComptrollerImplementationV2";
+import { handleEntity } from "./handlers";
+
+export function handleCompBorrowSpeedUpdated(event: CompBorrowSpeedUpdatedEvent): void {
+  handleEntity(
+    event.transaction.hash,
+    event.block.number,
+    event.block.timestamp,
+    event.address, // comptrollerAddress
+    event.params.newSpeed,
+    null,
+    event.params.cToken,
+    null, // borrowIndex
+    null, // totalBorrows
+  );
+}
+
+export function handleCompSupplySpeedUpdated(event: CompSupplySpeedUpdatedEvent): void {
+  handleEntity(
+    event.transaction.hash,
+    event.block.number,
+    event.block.timestamp,
+    event.address, // comptrollerAddress
+    null,
+    event.params.newSpeed,
+    event.params.cToken,
+    null, // borrowIndex
+    null, // totalBorrows
+  );
+}

--- a/src/Compound/mappings/Token.ts
+++ b/src/Compound/mappings/Token.ts
@@ -18,7 +18,8 @@ export function handleAccrueInterest(event: AccrueInterestEvent): void {
     event.block.number,
     event.block.timestamp,
     null, // comptrollerAddress
-    null, // newSpeed
+    null, // newBorrowSpeed
+    null, // newSupplySpeed
     event.address, // cTokenAddress
     event.params.borrowIndex,
     event.params.totalBorrows,
@@ -31,7 +32,8 @@ export function handleBorrow(event: BorrowEvent): void {
     event.block.number,
     event.block.timestamp,
     null, // comptrollerAddress
-    null, // newSpeed
+    null, // newBorrowSpeed
+    null, // newSupplySpeed
     event.address, // cTokenAddress
     null, // borrowIndex
     event.params.totalBorrows,
@@ -44,7 +46,8 @@ export function handleLiquidateBorrow(event: LiquidateBorrowEvent): void {
     event.block.number,
     event.block.timestamp,
     null, // comptrollerAddress
-    null, // newSpeed
+    null, // newBorrowSpeed
+    null, // newSupplySpeed
     event.address, // cTokenAddress
     null, // borrowIndex
     null, // totalBorrows
@@ -57,7 +60,8 @@ export function handleMint(event: MintEvent): void {
     event.block.number,
     event.block.timestamp,
     null, // comptrollerAddress
-    null, // newSpeed
+    null, // newBorrowSpeed
+    null, // newSupplySpeed
     event.address, // cTokenAddress
     null, // borrowIndex
     null, // totalBorrows
@@ -70,7 +74,8 @@ export function handleNewReserveFactor(event: NewReserveFactorEvent): void {
     event.block.number,
     event.block.timestamp,
     null, // comptrollerAddress
-    null, // newSpeed
+    null, // newBorrowSpeed
+    null, // newSupplySpeed
     event.address, // cTokenAddress
     null, // borrowIndex
     null, // totalBorrows
@@ -83,7 +88,8 @@ export function handleRedeem(event: RedeemEvent): void {
     event.block.number,
     event.block.timestamp,
     null, // comptrollerAddress
-    null, // newSpeed
+    null, // newBorrowSpeed
+    null, // newSupplySpeed
     event.address, // cTokenAddress
     null, // borrowIndex
     null, // totalBorrows
@@ -96,7 +102,8 @@ export function handleRepayBorrow(event: RepayBorrowEvent): void {
     event.block.number,
     event.block.timestamp,
     null, // comptrollerAddress
-    null, // newSpeed
+    null, // newBorrowSpeed
+    null, // newSupplySpeed
     event.address, // cTokenAddress
     null, // borrowIndex
     event.params.totalBorrows,
@@ -109,7 +116,8 @@ export function handleReservesAdded(event: ReservesAddedEvent): void {
     event.block.number,
     event.block.timestamp,
     null, // comptrollerAddress
-    null, // newSpeed
+    null, // newBorrowSpeed
+    null, // newSupplySpeed
     event.address, // cTokenAddress
     null, // borrowIndex
     null, // totalBorrows
@@ -122,7 +130,8 @@ export function handleReservesReduced(event: ReservesReducedEvent): void {
     event.block.number,
     event.block.timestamp,
     null, // comptrollerAddress
-    null, // newSpeed
+    null, // newBorrowSpeed
+    null, // newSupplySpeed
     event.address, // cTokenAddress
     null, // borrowIndex
     null, // totalBorrows
@@ -135,7 +144,8 @@ export function handleTransfer(event: TransferEvent): void {
     event.block.number,
     event.block.timestamp,
     null, // comptrollerAddress
-    null, // newSpeed
+    null, // newBorrowSpeed
+    null, // newSupplySpeed
     event.address, // cTokenAddress
     null, // borrowIndex
     null, // totalBorrows


### PR DESCRIPTION
Fixes #OE-49

In September 2021 Compound split `compSpeed` into `compBorrowSpeed` and `compSupplySpeed`. So since block 13322798 the existing subgraph returned 0 as `compSpeed`.

Deployed at https://thegraph.com/hosted-service/subgraph/uwe/compound (but still syncing).