### PR TITLE
Curve: use calc_withdraw_one_coin()

### DIFF
--- a/src/Curve/abis/PoolX2_128.json
+++ b/src/Curve/abis/PoolX2_128.json
@@ -89,5 +89,15 @@
     "inputs": [{ "type": "int128", "name": "arg0" }],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "name": "calc_withdraw_one_coin",
+    "outputs": [{ "type": "uint256", "name": "" }],
+    "inputs": [
+      { "type": "uint256", "name": "_token_amount" },
+      { "type": "int128", "name": "i" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/src/Curve/abis/PoolX2_256.json
+++ b/src/Curve/abis/PoolX2_256.json
@@ -89,5 +89,15 @@
     "inputs": [{ "type": "uint256", "name": "arg0" }],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "name": "calc_withdraw_one_coin",
+    "outputs": [{ "type": "uint256", "name": "" }],
+    "inputs": [
+      { "type": "uint256", "name": "_token_amount" },
+      { "type": "int128", "name": "i" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/src/Curve/abis/PoolX3_128.json
+++ b/src/Curve/abis/PoolX3_128.json
@@ -89,5 +89,15 @@
     "inputs": [{ "type": "int128", "name": "arg0" }],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "name": "calc_withdraw_one_coin",
+    "outputs": [{ "type": "uint256", "name": "" }],
+    "inputs": [
+      { "type": "uint256", "name": "_token_amount" },
+      { "type": "int128", "name": "i" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/src/Curve/abis/PoolX3_256.json
+++ b/src/Curve/abis/PoolX3_256.json
@@ -89,5 +89,15 @@
     "inputs": [{ "type": "uint256", "name": "arg0" }],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "name": "calc_withdraw_one_coin",
+    "outputs": [{ "type": "uint256", "name": "" }],
+    "inputs": [
+      { "type": "uint256", "name": "_token_amount" },
+      { "type": "int128", "name": "i" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/src/Curve/abis/PoolX4_128.json
+++ b/src/Curve/abis/PoolX4_128.json
@@ -92,5 +92,15 @@
     "constant": true,
     "payable": false,
     "type": "function"
+  },
+  {
+    "name": "calc_withdraw_one_coin",
+    "outputs": [{ "type": "uint256", "name": "" }],
+    "inputs": [
+      { "type": "uint256", "name": "_token_amount" },
+      { "type": "int128", "name": "i" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/src/Curve/abis/PoolX4_256.json
+++ b/src/Curve/abis/PoolX4_256.json
@@ -92,5 +92,15 @@
     "constant": true,
     "payable": false,
     "type": "function"
+  },
+  {
+    "name": "calc_withdraw_one_coin",
+    "outputs": [{ "type": "uint256", "name": "" }],
+    "inputs": [
+      { "type": "uint256", "name": "_token_amount" },
+      { "type": "int128", "name": "i" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/src/Curve/mappings/PoolX2_128.ts
+++ b/src/Curve/mappings/PoolX2_128.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../generated/CurvePoolX2_128/CurvePoolX2_128";
 import { CurveERC20 } from "../../../generated/Curve/CurveERC20";
 import { CurvePoolData } from "../../../generated/schema";
-import { ZERO_BD, ZERO_BYTES } from "../../utils/constants";
+import { CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT, ZERO_BD, ZERO_BYTES } from "../../utils/constants";
 import { convertBINumToDesiredDecimals, toBytes } from "../../utils/converters";
 import { getExtras } from "./extras";
 import { getWorkingSupply } from "./shared";
@@ -93,21 +93,27 @@ function handlePoolEntity(
 
   let contract = CurvePoolX2_128.bind(vault);
 
-  // balance and tokens arrays
+  // balance, tokens and underlying per LP arrays
 
   let balances: Array<BigDecimal> = [];
   let tokens: Array<Bytes> = [];
-  for (let i = 0; i < 2; i++) {
+  let underlyingPerLpTokens: Array<BigDecimal> = [];
+  for (let i = 0; i < 4; i++) {
     let balanceResult = contract.try_balances(BigInt.fromI32(i));
     let tokenResult = contract.try_coins(BigInt.fromI32(i));
+    let calcWithdrawOneCoinResult = contract.try_calc_withdraw_one_coin(
+      CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT,
+      BigInt.fromI32(i),
+    );
 
     let balance = ZERO_BD;
     let token = ZERO_BYTES;
+    let underlyingPerLpToken = ZERO_BD;
 
     if (balanceResult.reverted) {
-      log.warning("{} ({}) balances({}) reverted", [poolType, vault.toHexString(), `${i}`]);
+      log.warning("{} ({}) balances({}) reverted", [poolType, vault.toHexString(), i.toString()]);
     } else if (tokenResult.reverted) {
-      log.warning("{} ({}) coins({}) reverted", [poolType, vault.toHexString(), `${i}`]);
+      log.warning("{} ({}) coins({}) reverted", [poolType, vault.toHexString(), i.toString()]);
     } else {
       let tokenContract = CurveERC20.bind(tokenResult.value);
       let decimalResult = tokenContract.try_decimals();
@@ -119,11 +125,27 @@ function handlePoolEntity(
       token = toBytes(tokenResult.value.toHex());
     }
 
+    if (calcWithdrawOneCoinResult.reverted) {
+      log.warning("{} ({}) calc_withdraw_one_coin({}, {}) reverted", [
+        poolType,
+        vault.toHexString(),
+        CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT.toString(),
+        i.toString(),
+      ]);
+    } else {
+      underlyingPerLpToken = calcWithdrawOneCoinResult.value
+        .toBigDecimal()
+        .div(CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT.toBigDecimal());
+    }
+
     balances.push(balance);
     tokens.push(token);
+    underlyingPerLpTokens.push(underlyingPerLpToken);
   }
+
   entity.balance = balances;
   entity.tokens = tokens;
+  entity.underlyingPerLpToken = underlyingPerLpTokens;
 
   // virtual price
 

--- a/src/Curve/mappings/PoolX2_128.ts
+++ b/src/Curve/mappings/PoolX2_128.ts
@@ -1,4 +1,4 @@
-import { Address, BigDecimal, BigInt, Bytes, ethereum, log } from "@graphprotocol/graph-ts";
+import { Address, BigDecimal, BigInt, Bytes, log } from "@graphprotocol/graph-ts";
 import {
   CurvePoolX2_128,
   AddLiquidity as AddLiquidityEvent,
@@ -9,12 +9,11 @@ import {
   TokenExchangeUnderlying as TokenExchangeUnderlyingEvent,
 } from "../../../generated/CurvePoolX2_128/CurvePoolX2_128";
 import { CurveERC20 } from "../../../generated/Curve/CurveERC20";
-import { CurveRegistry } from "../../../generated/Curve/CurveRegistry";
-import { CurveLiquidityGaugeCommon } from "../../../generated/Curve/CurveLiquidityGaugeCommon";
 import { CurvePoolData } from "../../../generated/schema";
-import { CurveRegistryAddress, CURVE_REGISTRY_START_BLOCK, ZERO_BD, ZERO_BYTES } from "../../utils/constants";
-import { convertBINumToDesiredDecimals, convertBytesToAddress, toBytes } from "../../utils/converters";
+import { ZERO_BD, ZERO_BYTES } from "../../utils/constants";
+import { convertBINumToDesiredDecimals, toBytes } from "../../utils/converters";
 import { getExtras } from "./extras";
+import { getWorkingSupply } from "./shared";
 
 export function handleAddLiquidity(event: AddLiquidityEvent): void {
   handlePoolEntity(
@@ -140,23 +139,7 @@ function handlePoolEntity(
 
   // working supply
 
-  entity.workingSupply = ZERO_BD;
-  if (blockNumber > CURVE_REGISTRY_START_BLOCK) {
-    let CurveRegistryContract = CurveRegistry.bind(CurveRegistryAddress);
-    let getGaugesResult = CurveRegistryContract.try_get_gauges(convertBytesToAddress(entity.vault));
-    if (getGaugesResult.reverted) {
-      log.warning("get_gauges reverted", []);
-    } else {
-      let gaugeAddress = convertBytesToAddress(getGaugesResult.value.value0[0]);
-      let gaugeContract = CurveLiquidityGaugeCommon.bind(gaugeAddress);
-      let workingSupplyResult = gaugeContract.try_working_supply();
-      if (workingSupplyResult.reverted) {
-        log.warning("working_supply reverted", []);
-      } else {
-        entity.workingSupply = convertBINumToDesiredDecimals(workingSupplyResult.value, 18);
-      }
-    }
-  }
+  entity.workingSupply = getWorkingSupply(vault, blockNumber);
 
   entity.save();
 }

--- a/src/Curve/mappings/PoolX2_256.ts
+++ b/src/Curve/mappings/PoolX2_256.ts
@@ -1,4 +1,4 @@
-import { Address, BigDecimal, BigInt, Bytes, ethereum, log } from "@graphprotocol/graph-ts";
+import { Address, BigDecimal, BigInt, Bytes, log } from "@graphprotocol/graph-ts";
 import {
   CurvePoolX2_256,
   AddLiquidity as AddLiquidityEvent,
@@ -9,12 +9,11 @@ import {
   TokenExchangeUnderlying as TokenExchangeUnderlyingEvent,
 } from "../../../generated/CurvePoolX2_256/CurvePoolX2_256";
 import { CurveERC20 } from "../../../generated/Curve/CurveERC20";
-import { CurveRegistry } from "../../../generated/Curve/CurveRegistry";
-import { CurveLiquidityGaugeCommon } from "../../../generated/Curve/CurveLiquidityGaugeCommon";
 import { CurvePoolData } from "../../../generated/schema";
-import { CurveRegistryAddress, CURVE_REGISTRY_START_BLOCK, ZERO_BD, ZERO_BYTES } from "../../utils/constants";
-import { convertBINumToDesiredDecimals, convertBytesToAddress, toBytes } from "../../utils/converters";
+import { ZERO_BD, ZERO_BYTES } from "../../utils/constants";
+import { convertBINumToDesiredDecimals, toBytes } from "../../utils/converters";
 import { getExtras } from "./extras";
+import { getWorkingSupply } from "./shared";
 
 export function handleAddLiquidity(event: AddLiquidityEvent): void {
   handlePoolEntity(
@@ -140,23 +139,7 @@ function handlePoolEntity(
 
   // working supply
 
-  entity.workingSupply = ZERO_BD;
-  if (blockNumber > CURVE_REGISTRY_START_BLOCK) {
-    let CurveRegistryContract = CurveRegistry.bind(CurveRegistryAddress);
-    let getGaugesResult = CurveRegistryContract.try_get_gauges(convertBytesToAddress(entity.vault));
-    if (getGaugesResult.reverted) {
-      log.warning("get_gauges reverted", []);
-    } else {
-      let gaugeAddress = convertBytesToAddress(getGaugesResult.value.value0[0]);
-      let gaugeContract = CurveLiquidityGaugeCommon.bind(gaugeAddress);
-      let workingSupplyResult = gaugeContract.try_working_supply();
-      if (workingSupplyResult.reverted) {
-        log.warning("working_supply reverted", []);
-      } else {
-        entity.workingSupply = convertBINumToDesiredDecimals(workingSupplyResult.value, 18);
-      }
-    }
-  }
+  entity.workingSupply = getWorkingSupply(vault, blockNumber);
 
   entity.save();
 }

--- a/src/Curve/mappings/PoolX2_256.ts
+++ b/src/Curve/mappings/PoolX2_256.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../generated/CurvePoolX2_256/CurvePoolX2_256";
 import { CurveERC20 } from "../../../generated/Curve/CurveERC20";
 import { CurvePoolData } from "../../../generated/schema";
-import { ZERO_BD, ZERO_BYTES } from "../../utils/constants";
+import { CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT, ZERO_BD, ZERO_BYTES } from "../../utils/constants";
 import { convertBINumToDesiredDecimals, toBytes } from "../../utils/converters";
 import { getExtras } from "./extras";
 import { getWorkingSupply } from "./shared";
@@ -93,21 +93,27 @@ function handlePoolEntity(
 
   let contract = CurvePoolX2_256.bind(vault);
 
-  // balance and tokens arrays
+  // balance, tokens and underlying per LP arrays
 
   let balances: Array<BigDecimal> = [];
   let tokens: Array<Bytes> = [];
-  for (let i = 0; i < 2; i++) {
+  let underlyingPerLpTokens: Array<BigDecimal> = [];
+  for (let i = 0; i < 4; i++) {
     let balanceResult = contract.try_balances(BigInt.fromI32(i));
     let tokenResult = contract.try_coins(BigInt.fromI32(i));
+    let calcWithdrawOneCoinResult = contract.try_calc_withdraw_one_coin(
+      CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT,
+      BigInt.fromI32(i),
+    );
 
     let balance = ZERO_BD;
     let token = ZERO_BYTES;
+    let underlyingPerLpToken = ZERO_BD;
 
     if (balanceResult.reverted) {
-      log.warning("{} ({}) balances({}) reverted", [poolType, vault.toHexString(), `${i}`]);
+      log.warning("{} ({}) balances({}) reverted", [poolType, vault.toHexString(), i.toString()]);
     } else if (tokenResult.reverted) {
-      log.warning("{} ({}) coins({}) reverted", [poolType, vault.toHexString(), `${i}`]);
+      log.warning("{} ({}) coins({}) reverted", [poolType, vault.toHexString(), i.toString()]);
     } else {
       let tokenContract = CurveERC20.bind(tokenResult.value);
       let decimalResult = tokenContract.try_decimals();
@@ -119,11 +125,27 @@ function handlePoolEntity(
       token = toBytes(tokenResult.value.toHex());
     }
 
+    if (calcWithdrawOneCoinResult.reverted) {
+      log.warning("{} ({}) calc_withdraw_one_coin({}, {}) reverted", [
+        poolType,
+        vault.toHexString(),
+        CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT.toString(),
+        i.toString(),
+      ]);
+    } else {
+      underlyingPerLpToken = calcWithdrawOneCoinResult.value
+        .toBigDecimal()
+        .div(CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT.toBigDecimal());
+    }
+
     balances.push(balance);
     tokens.push(token);
+    underlyingPerLpTokens.push(underlyingPerLpToken);
   }
+
   entity.balance = balances;
   entity.tokens = tokens;
+  entity.underlyingPerLpToken = underlyingPerLpTokens;
 
   // virtual price
 

--- a/src/Curve/mappings/PoolX3_128.ts
+++ b/src/Curve/mappings/PoolX3_128.ts
@@ -1,4 +1,4 @@
-import { Address, BigDecimal, BigInt, Bytes, ethereum, log } from "@graphprotocol/graph-ts";
+import { Address, BigDecimal, BigInt, Bytes, log } from "@graphprotocol/graph-ts";
 import {
   CurvePoolX3_128,
   AddLiquidity as AddLiquidityEvent,
@@ -9,12 +9,11 @@ import {
   TokenExchangeUnderlying as TokenExchangeUnderlyingEvent,
 } from "../../../generated/CurvePoolX3_128/CurvePoolX3_128";
 import { CurveERC20 } from "../../../generated/Curve/CurveERC20";
-import { CurveRegistry } from "../../../generated/Curve/CurveRegistry";
-import { CurveLiquidityGaugeCommon } from "../../../generated/Curve/CurveLiquidityGaugeCommon";
 import { CurvePoolData } from "../../../generated/schema";
-import { CurveRegistryAddress, CURVE_REGISTRY_START_BLOCK, ZERO_BD, ZERO_BYTES } from "../../utils/constants";
-import { convertBINumToDesiredDecimals, convertBytesToAddress, toBytes } from "../../utils/converters";
+import { ZERO_BD, ZERO_BYTES } from "../../utils/constants";
+import { convertBINumToDesiredDecimals, toBytes } from "../../utils/converters";
 import { getExtras } from "./extras";
+import { getWorkingSupply } from "./shared";
 
 export function handleAddLiquidity(event: AddLiquidityEvent): void {
   handlePoolEntity(
@@ -140,23 +139,7 @@ function handlePoolEntity(
 
   // working supply
 
-  entity.workingSupply = ZERO_BD;
-  if (blockNumber > CURVE_REGISTRY_START_BLOCK) {
-    let CurveRegistryContract = CurveRegistry.bind(CurveRegistryAddress);
-    let getGaugesResult = CurveRegistryContract.try_get_gauges(convertBytesToAddress(entity.vault));
-    if (getGaugesResult.reverted) {
-      log.warning("get_gauges reverted", []);
-    } else {
-      let gaugeAddress = convertBytesToAddress(getGaugesResult.value.value0[0]);
-      let gaugeContract = CurveLiquidityGaugeCommon.bind(gaugeAddress);
-      let workingSupplyResult = gaugeContract.try_working_supply();
-      if (workingSupplyResult.reverted) {
-        log.warning("working_supply reverted", []);
-      } else {
-        entity.workingSupply = convertBINumToDesiredDecimals(workingSupplyResult.value, 18);
-      }
-    }
-  }
+  entity.workingSupply = getWorkingSupply(vault, blockNumber);
 
   entity.save();
 }

--- a/src/Curve/mappings/PoolX3_128.ts
+++ b/src/Curve/mappings/PoolX3_128.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../generated/CurvePoolX3_128/CurvePoolX3_128";
 import { CurveERC20 } from "../../../generated/Curve/CurveERC20";
 import { CurvePoolData } from "../../../generated/schema";
-import { ZERO_BD, ZERO_BYTES } from "../../utils/constants";
+import { CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT, ZERO_BD, ZERO_BYTES } from "../../utils/constants";
 import { convertBINumToDesiredDecimals, toBytes } from "../../utils/converters";
 import { getExtras } from "./extras";
 import { getWorkingSupply } from "./shared";
@@ -93,21 +93,27 @@ function handlePoolEntity(
 
   let contract = CurvePoolX3_128.bind(vault);
 
-  // balance and tokens arrays
+  // balance, tokens and underlying per LP arrays
 
   let balances: Array<BigDecimal> = [];
   let tokens: Array<Bytes> = [];
-  for (let i = 0; i < 3; i++) {
+  let underlyingPerLpTokens: Array<BigDecimal> = [];
+  for (let i = 0; i < 4; i++) {
     let balanceResult = contract.try_balances(BigInt.fromI32(i));
     let tokenResult = contract.try_coins(BigInt.fromI32(i));
+    let calcWithdrawOneCoinResult = contract.try_calc_withdraw_one_coin(
+      CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT,
+      BigInt.fromI32(i),
+    );
 
     let balance = ZERO_BD;
     let token = ZERO_BYTES;
+    let underlyingPerLpToken = ZERO_BD;
 
     if (balanceResult.reverted) {
-      log.warning("{} ({}) balances({}) reverted", [poolType, vault.toHexString(), `${i}`]);
+      log.warning("{} ({}) balances({}) reverted", [poolType, vault.toHexString(), i.toString()]);
     } else if (tokenResult.reverted) {
-      log.warning("{} ({}) coins({}) reverted", [poolType, vault.toHexString(), `${i}`]);
+      log.warning("{} ({}) coins({}) reverted", [poolType, vault.toHexString(), i.toString()]);
     } else {
       let tokenContract = CurveERC20.bind(tokenResult.value);
       let decimalResult = tokenContract.try_decimals();
@@ -119,11 +125,27 @@ function handlePoolEntity(
       token = toBytes(tokenResult.value.toHex());
     }
 
+    if (calcWithdrawOneCoinResult.reverted) {
+      log.warning("{} ({}) calc_withdraw_one_coin({}, {}) reverted", [
+        poolType,
+        vault.toHexString(),
+        CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT.toString(),
+        i.toString(),
+      ]);
+    } else {
+      underlyingPerLpToken = calcWithdrawOneCoinResult.value
+        .toBigDecimal()
+        .div(CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT.toBigDecimal());
+    }
+
     balances.push(balance);
     tokens.push(token);
+    underlyingPerLpTokens.push(underlyingPerLpToken);
   }
+
   entity.balance = balances;
   entity.tokens = tokens;
+  entity.underlyingPerLpToken = underlyingPerLpTokens;
 
   // virtual price
 

--- a/src/Curve/mappings/PoolX3_256.ts
+++ b/src/Curve/mappings/PoolX3_256.ts
@@ -1,4 +1,4 @@
-import { Address, BigDecimal, BigInt, Bytes, ethereum, log } from "@graphprotocol/graph-ts";
+import { Address, BigDecimal, BigInt, Bytes, log } from "@graphprotocol/graph-ts";
 import {
   CurvePoolX3_256,
   AddLiquidity as AddLiquidityEvent,
@@ -9,12 +9,11 @@ import {
   TokenExchangeUnderlying as TokenExchangeUnderlyingEvent,
 } from "../../../generated/CurvePoolX3_256/CurvePoolX3_256";
 import { CurveERC20 } from "../../../generated/Curve/CurveERC20";
-import { CurveRegistry } from "../../../generated/Curve/CurveRegistry";
-import { CurveLiquidityGaugeCommon } from "../../../generated/Curve/CurveLiquidityGaugeCommon";
 import { CurvePoolData } from "../../../generated/schema";
-import { CurveRegistryAddress, CURVE_REGISTRY_START_BLOCK, ZERO_BD, ZERO_BYTES } from "../../utils/constants";
-import { convertBINumToDesiredDecimals, convertBytesToAddress, toBytes } from "../../utils/converters";
+import { ZERO_BD, ZERO_BYTES } from "../../utils/constants";
+import { convertBINumToDesiredDecimals, toBytes } from "../../utils/converters";
 import { getExtras } from "./extras";
+import { getWorkingSupply } from "./shared";
 
 export function handleAddLiquidity(event: AddLiquidityEvent): void {
   handlePoolEntity(
@@ -140,23 +139,7 @@ function handlePoolEntity(
 
   // working supply
 
-  entity.workingSupply = ZERO_BD;
-  if (blockNumber > CURVE_REGISTRY_START_BLOCK) {
-    let CurveRegistryContract = CurveRegistry.bind(CurveRegistryAddress);
-    let getGaugesResult = CurveRegistryContract.try_get_gauges(convertBytesToAddress(entity.vault));
-    if (getGaugesResult.reverted) {
-      log.warning("get_gauges reverted", []);
-    } else {
-      let gaugeAddress = convertBytesToAddress(getGaugesResult.value.value0[0]);
-      let gaugeContract = CurveLiquidityGaugeCommon.bind(gaugeAddress);
-      let workingSupplyResult = gaugeContract.try_working_supply();
-      if (workingSupplyResult.reverted) {
-        log.warning("working_supply reverted", []);
-      } else {
-        entity.workingSupply = convertBINumToDesiredDecimals(workingSupplyResult.value, 18);
-      }
-    }
-  }
+  entity.workingSupply = getWorkingSupply(vault, blockNumber);
 
   entity.save();
 }

--- a/src/Curve/mappings/PoolX3_256.ts
+++ b/src/Curve/mappings/PoolX3_256.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../generated/CurvePoolX3_256/CurvePoolX3_256";
 import { CurveERC20 } from "../../../generated/Curve/CurveERC20";
 import { CurvePoolData } from "../../../generated/schema";
-import { ZERO_BD, ZERO_BYTES } from "../../utils/constants";
+import { CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT, ZERO_BD, ZERO_BYTES } from "../../utils/constants";
 import { convertBINumToDesiredDecimals, toBytes } from "../../utils/converters";
 import { getExtras } from "./extras";
 import { getWorkingSupply } from "./shared";
@@ -93,21 +93,27 @@ function handlePoolEntity(
 
   let contract = CurvePoolX3_256.bind(vault);
 
-  // balance and tokens arrays
+  // balance, tokens and underlying per LP arrays
 
   let balances: Array<BigDecimal> = [];
   let tokens: Array<Bytes> = [];
-  for (let i = 0; i < 3; i++) {
+  let underlyingPerLpTokens: Array<BigDecimal> = [];
+  for (let i = 0; i < 4; i++) {
     let balanceResult = contract.try_balances(BigInt.fromI32(i));
     let tokenResult = contract.try_coins(BigInt.fromI32(i));
+    let calcWithdrawOneCoinResult = contract.try_calc_withdraw_one_coin(
+      CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT,
+      BigInt.fromI32(i),
+    );
 
     let balance = ZERO_BD;
     let token = ZERO_BYTES;
+    let underlyingPerLpToken = ZERO_BD;
 
     if (balanceResult.reverted) {
-      log.warning("{} ({}) balances({}) reverted", [poolType, vault.toHexString(), `${i}`]);
+      log.warning("{} ({}) balances({}) reverted", [poolType, vault.toHexString(), i.toString()]);
     } else if (tokenResult.reverted) {
-      log.warning("{} ({}) coins({}) reverted", [poolType, vault.toHexString(), `${i}`]);
+      log.warning("{} ({}) coins({}) reverted", [poolType, vault.toHexString(), i.toString()]);
     } else {
       let tokenContract = CurveERC20.bind(tokenResult.value);
       let decimalResult = tokenContract.try_decimals();
@@ -119,11 +125,27 @@ function handlePoolEntity(
       token = toBytes(tokenResult.value.toHex());
     }
 
+    if (calcWithdrawOneCoinResult.reverted) {
+      log.warning("{} ({}) calc_withdraw_one_coin({}, {}) reverted", [
+        poolType,
+        vault.toHexString(),
+        CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT.toString(),
+        i.toString(),
+      ]);
+    } else {
+      underlyingPerLpToken = calcWithdrawOneCoinResult.value
+        .toBigDecimal()
+        .div(CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT.toBigDecimal());
+    }
+
     balances.push(balance);
     tokens.push(token);
+    underlyingPerLpTokens.push(underlyingPerLpToken);
   }
+
   entity.balance = balances;
   entity.tokens = tokens;
+  entity.underlyingPerLpToken = underlyingPerLpTokens;
 
   // virtual price
 

--- a/src/Curve/mappings/PoolX4_128.ts
+++ b/src/Curve/mappings/PoolX4_128.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../generated/CurvePoolX4_128/CurvePoolX4_128";
 import { CurveERC20 } from "../../../generated/Curve/CurveERC20";
 import { CurvePoolData } from "../../../generated/schema";
-import { ZERO_BD, ZERO_BYTES } from "../../utils/constants";
+import { CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT, ZERO_BD, ZERO_BYTES } from "../../utils/constants";
 import { convertBINumToDesiredDecimals, toBytes } from "../../utils/converters";
 import { getExtras } from "./extras";
 import { getWorkingSupply } from "./shared";
@@ -93,21 +93,27 @@ function handlePoolEntity(
 
   let contract = CurvePoolX4_128.bind(vault);
 
-  // balance and tokens arrays
+  // balance, tokens and underlying per LP arrays
 
   let balances: Array<BigDecimal> = [];
   let tokens: Array<Bytes> = [];
+  let underlyingPerLpTokens: Array<BigDecimal> = [];
   for (let i = 0; i < 4; i++) {
     let balanceResult = contract.try_balances(BigInt.fromI32(i));
     let tokenResult = contract.try_coins(BigInt.fromI32(i));
+    let calcWithdrawOneCoinResult = contract.try_calc_withdraw_one_coin(
+      CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT,
+      BigInt.fromI32(i),
+    );
 
     let balance = ZERO_BD;
     let token = ZERO_BYTES;
+    let underlyingPerLpToken = ZERO_BD;
 
     if (balanceResult.reverted) {
-      log.warning("{} ({}) balances({}) reverted", [poolType, vault.toHexString(), `${i}`]);
+      log.warning("{} ({}) balances({}) reverted", [poolType, vault.toHexString(), i.toString()]);
     } else if (tokenResult.reverted) {
-      log.warning("{} ({}) coins({}) reverted", [poolType, vault.toHexString(), `${i}`]);
+      log.warning("{} ({}) coins({}) reverted", [poolType, vault.toHexString(), i.toString()]);
     } else {
       let tokenContract = CurveERC20.bind(tokenResult.value);
       let decimalResult = tokenContract.try_decimals();
@@ -119,11 +125,27 @@ function handlePoolEntity(
       token = toBytes(tokenResult.value.toHex());
     }
 
+    if (calcWithdrawOneCoinResult.reverted) {
+      log.warning("{} ({}) calc_withdraw_one_coin({}, {}) reverted", [
+        poolType,
+        vault.toHexString(),
+        CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT.toString(),
+        i.toString(),
+      ]);
+    } else {
+      underlyingPerLpToken = calcWithdrawOneCoinResult.value
+        .toBigDecimal()
+        .div(CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT.toBigDecimal());
+    }
+
     balances.push(balance);
     tokens.push(token);
+    underlyingPerLpTokens.push(underlyingPerLpToken);
   }
+
   entity.balance = balances;
   entity.tokens = tokens;
+  entity.underlyingPerLpToken = underlyingPerLpTokens;
 
   // virtual price
 

--- a/src/Curve/mappings/PoolX4_128.ts
+++ b/src/Curve/mappings/PoolX4_128.ts
@@ -1,4 +1,4 @@
-import { Address, BigDecimal, BigInt, Bytes, ethereum, log } from "@graphprotocol/graph-ts";
+import { Address, BigDecimal, BigInt, Bytes, log } from "@graphprotocol/graph-ts";
 import {
   CurvePoolX4_128,
   AddLiquidity as AddLiquidityEvent,
@@ -9,12 +9,11 @@ import {
   TokenExchangeUnderlying as TokenExchangeUnderlyingEvent,
 } from "../../../generated/CurvePoolX4_128/CurvePoolX4_128";
 import { CurveERC20 } from "../../../generated/Curve/CurveERC20";
-import { CurveRegistry } from "../../../generated/Curve/CurveRegistry";
-import { CurveLiquidityGaugeCommon } from "../../../generated/Curve/CurveLiquidityGaugeCommon";
 import { CurvePoolData } from "../../../generated/schema";
-import { CurveRegistryAddress, CURVE_REGISTRY_START_BLOCK, ZERO_BD, ZERO_BYTES } from "../../utils/constants";
-import { convertBINumToDesiredDecimals, convertBytesToAddress, toBytes } from "../../utils/converters";
+import { ZERO_BD, ZERO_BYTES } from "../../utils/constants";
+import { convertBINumToDesiredDecimals, toBytes } from "../../utils/converters";
 import { getExtras } from "./extras";
+import { getWorkingSupply } from "./shared";
 
 export function handleAddLiquidity(event: AddLiquidityEvent): void {
   handlePoolEntity(
@@ -140,23 +139,7 @@ function handlePoolEntity(
 
   // working supply
 
-  entity.workingSupply = ZERO_BD;
-  if (blockNumber > CURVE_REGISTRY_START_BLOCK) {
-    let CurveRegistryContract = CurveRegistry.bind(CurveRegistryAddress);
-    let getGaugesResult = CurveRegistryContract.try_get_gauges(convertBytesToAddress(entity.vault));
-    if (getGaugesResult.reverted) {
-      log.warning("get_gauges reverted", []);
-    } else {
-      let gaugeAddress = convertBytesToAddress(getGaugesResult.value.value0[0]);
-      let gaugeContract = CurveLiquidityGaugeCommon.bind(gaugeAddress);
-      let workingSupplyResult = gaugeContract.try_working_supply();
-      if (workingSupplyResult.reverted) {
-        log.warning("working_supply reverted", []);
-      } else {
-        entity.workingSupply = convertBINumToDesiredDecimals(workingSupplyResult.value, 18);
-      }
-    }
-  }
+  entity.workingSupply = getWorkingSupply(vault, blockNumber);
 
   entity.save();
 }

--- a/src/Curve/mappings/PoolX4_256.ts
+++ b/src/Curve/mappings/PoolX4_256.ts
@@ -1,4 +1,4 @@
-import { Address, BigDecimal, BigInt, Bytes, ethereum, log } from "@graphprotocol/graph-ts";
+import { Address, BigDecimal, BigInt, Bytes, log } from "@graphprotocol/graph-ts";
 import {
   CurvePoolX4_256,
   AddLiquidity as AddLiquidityEvent,
@@ -9,12 +9,11 @@ import {
   TokenExchangeUnderlying as TokenExchangeUnderlyingEvent,
 } from "../../../generated/CurvePoolX4_256/CurvePoolX4_256";
 import { CurveERC20 } from "../../../generated/Curve/CurveERC20";
-import { CurveRegistry } from "../../../generated/Curve/CurveRegistry";
-import { CurveLiquidityGaugeCommon } from "../../../generated/Curve/CurveLiquidityGaugeCommon";
 import { CurvePoolData } from "../../../generated/schema";
-import { CurveRegistryAddress, CURVE_REGISTRY_START_BLOCK, ZERO_BD, ZERO_BYTES } from "../../utils/constants";
-import { convertBINumToDesiredDecimals, convertBytesToAddress, toBytes } from "../../utils/converters";
+import { ZERO_BD, ZERO_BYTES } from "../../utils/constants";
+import { convertBINumToDesiredDecimals, toBytes } from "../../utils/converters";
 import { getExtras } from "./extras";
+import { getWorkingSupply } from "./shared";
 
 export function handleAddLiquidity(event: AddLiquidityEvent): void {
   handlePoolEntity(
@@ -140,23 +139,7 @@ function handlePoolEntity(
 
   // working supply
 
-  entity.workingSupply = ZERO_BD;
-  if (blockNumber > CURVE_REGISTRY_START_BLOCK) {
-    let CurveRegistryContract = CurveRegistry.bind(CurveRegistryAddress);
-    let getGaugesResult = CurveRegistryContract.try_get_gauges(convertBytesToAddress(entity.vault));
-    if (getGaugesResult.reverted) {
-      log.warning("get_gauges reverted", []);
-    } else {
-      let gaugeAddress = convertBytesToAddress(getGaugesResult.value.value0[0]);
-      let gaugeContract = CurveLiquidityGaugeCommon.bind(gaugeAddress);
-      let workingSupplyResult = gaugeContract.try_working_supply();
-      if (workingSupplyResult.reverted) {
-        log.warning("working_supply reverted", []);
-      } else {
-        entity.workingSupply = convertBINumToDesiredDecimals(workingSupplyResult.value, 18);
-      }
-    }
-  }
+  entity.workingSupply = getWorkingSupply(vault, blockNumber);
 
   entity.save();
 }

--- a/src/Curve/mappings/PoolX4_256.ts
+++ b/src/Curve/mappings/PoolX4_256.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../generated/CurvePoolX4_256/CurvePoolX4_256";
 import { CurveERC20 } from "../../../generated/Curve/CurveERC20";
 import { CurvePoolData } from "../../../generated/schema";
-import { ZERO_BD, ZERO_BYTES } from "../../utils/constants";
+import { CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT, ZERO_BD, ZERO_BYTES } from "../../utils/constants";
 import { convertBINumToDesiredDecimals, toBytes } from "../../utils/converters";
 import { getExtras } from "./extras";
 import { getWorkingSupply } from "./shared";
@@ -93,21 +93,27 @@ function handlePoolEntity(
 
   let contract = CurvePoolX4_256.bind(vault);
 
-  // balance and tokens arrays
+  // balance, tokens and underlying per LP arrays
 
   let balances: Array<BigDecimal> = [];
   let tokens: Array<Bytes> = [];
+  let underlyingPerLpTokens: Array<BigDecimal> = [];
   for (let i = 0; i < 4; i++) {
     let balanceResult = contract.try_balances(BigInt.fromI32(i));
     let tokenResult = contract.try_coins(BigInt.fromI32(i));
+    let calcWithdrawOneCoinResult = contract.try_calc_withdraw_one_coin(
+      CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT,
+      BigInt.fromI32(i),
+    );
 
     let balance = ZERO_BD;
     let token = ZERO_BYTES;
+    let underlyingPerLpToken = ZERO_BD;
 
     if (balanceResult.reverted) {
-      log.warning("{} ({}) balances({}) reverted", [poolType, vault.toHexString(), `${i}`]);
+      log.warning("{} ({}) balances({}) reverted", [poolType, vault.toHexString(), i.toString()]);
     } else if (tokenResult.reverted) {
-      log.warning("{} ({}) coins({}) reverted", [poolType, vault.toHexString(), `${i}`]);
+      log.warning("{} ({}) coins({}) reverted", [poolType, vault.toHexString(), i.toString()]);
     } else {
       let tokenContract = CurveERC20.bind(tokenResult.value);
       let decimalResult = tokenContract.try_decimals();
@@ -119,11 +125,27 @@ function handlePoolEntity(
       token = toBytes(tokenResult.value.toHex());
     }
 
+    if (calcWithdrawOneCoinResult.reverted) {
+      log.warning("{} ({}) calc_withdraw_one_coin({}, {}) reverted", [
+        poolType,
+        vault.toHexString(),
+        CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT.toString(),
+        i.toString(),
+      ]);
+    } else {
+      underlyingPerLpToken = calcWithdrawOneCoinResult.value
+        .toBigDecimal()
+        .div(CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT.toBigDecimal());
+    }
+
     balances.push(balance);
     tokens.push(token);
+    underlyingPerLpTokens.push(underlyingPerLpToken);
   }
+
   entity.balance = balances;
   entity.tokens = tokens;
+  entity.underlyingPerLpToken = underlyingPerLpTokens;
 
   // virtual price
 

--- a/src/Curve/mappings/shared.ts
+++ b/src/Curve/mappings/shared.ts
@@ -1,0 +1,29 @@
+import { Address, BigDecimal, BigInt, log } from "@graphprotocol/graph-ts";
+import { CurveRegistry } from "../../../generated/Curve/CurveRegistry";
+import { CurveLiquidityGaugeCommon } from "../../../generated/Curve/CurveLiquidityGaugeCommon";
+import { CurveRegistryAddress, CURVE_REGISTRY_START_BLOCK, ZERO_BD } from "../../utils/constants";
+import { convertBINumToDesiredDecimals, convertBytesToAddress } from "../../utils/converters";
+
+
+export function getWorkingSupply(vault: Address, blockNumber: BigInt): BigDecimal {
+  if (blockNumber.lt(CURVE_REGISTRY_START_BLOCK)) {
+    return ZERO_BD;
+  }
+
+  let CurveRegistryContract = CurveRegistry.bind(CurveRegistryAddress);
+  let getGaugesResult = CurveRegistryContract.try_get_gauges(convertBytesToAddress(vault));
+  if (getGaugesResult.reverted) {
+    log.warning("get_gauges reverted", []);
+    return ZERO_BD;
+  } else {
+    let gaugeAddress = convertBytesToAddress(getGaugesResult.value.value0[0]);
+    let gaugeContract = CurveLiquidityGaugeCommon.bind(gaugeAddress);
+    let workingSupplyResult = gaugeContract.try_working_supply();
+    if (workingSupplyResult.reverted) {
+      log.warning("working_supply reverted", []);
+      return ZERO_BD;
+    } else {
+      return convertBINumToDesiredDecimals(workingSupplyResult.value, 18);
+    }
+  }
+}

--- a/src/Curve/mappings/shared.ts
+++ b/src/Curve/mappings/shared.ts
@@ -4,7 +4,6 @@ import { CurveLiquidityGaugeCommon } from "../../../generated/Curve/CurveLiquidi
 import { CurveRegistryAddress, CURVE_REGISTRY_START_BLOCK, ZERO_BD } from "../../utils/constants";
 import { convertBINumToDesiredDecimals, convertBytesToAddress } from "../../utils/converters";
 
-
 export function getWorkingSupply(vault: Address, blockNumber: BigInt): BigDecimal {
   if (blockNumber.lt(CURVE_REGISTRY_START_BLOCK)) {
     return ZERO_BD;

--- a/src/Curve/schema.graphql
+++ b/src/Curve/schema.graphql
@@ -12,6 +12,7 @@ type CurvePoolData @entity {
   vault: Bytes!
   balance: [BigDecimal!]!
   virtualPrice: BigDecimal!
+  underlyingPerLpToken: [BigDecimal!]!
   tokens: [Bytes!]!
   extras: [CurveExtraReward!]
   workingSupply: BigDecimal!

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -14,7 +14,8 @@ export let ConvexBoosterAddress = toAddress("0xf403c135812408bfbe8713b5a23a04b3d
 export let ConvexTokenAddress = toAddress("0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B");
 
 export let CurveRegistryAddress = toAddress("0x90e00ace148ca3b23ac1bc8c240c2a7dd9c2d7f5");
-export const CURVE_REGISTRY_START_BLOCK = BigInt.fromI32(12195750);
+export let CURVE_REGISTRY_START_BLOCK = BigInt.fromI32(12195750);
+export let CURVE_CALC_WITHDRAW_ONE_COIN_AMOUNT = BigInt.fromI32(1000000);
 
 export let DForce_dDAI: Address = toAddress("0x02285AcaafEB533e03A7306C55EC031297df9224");
 export let DForce_dDAI_Staking: Address = toAddress("0xD2fA07cD6Cd4A5A96aa86BacfA6E50bB3aaDBA8B");

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -14,9 +14,7 @@ export let ConvexBoosterAddress = toAddress("0xf403c135812408bfbe8713b5a23a04b3d
 export let ConvexTokenAddress = toAddress("0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B");
 
 export let CurveRegistryAddress = toAddress("0x90e00ace148ca3b23ac1bc8c240c2a7dd9c2d7f5");
-export const Curve_N_COINS_CURVE2POOL: number = 2;
-export const Curve_N_COINS_CURVE3POOL: number = 3;
-export const Curve_N_COINS_CURVE4POOL: number = 4;
+export const CURVE_REGISTRY_START_BLOCK = BigInt.fromI32(12195750);
 
 export let DForce_dDAI: Address = toAddress("0x02285AcaafEB533e03A7306C55EC031297df9224");
 export let DForce_dDAI_Staking: Address = toAddress("0xD2fA07cD6Cd4A5A96aa86BacfA6E50bB3aaDBA8B");


### PR DESCRIPTION
Add `calc_withdraw_one_coin()` to calculate underlying losses.

Deployed to: https://thegraph.com/hosted-service/subgraph/uwe/curve-ethereum?version=pending